### PR TITLE
Obecny stan projektu

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -39,6 +39,7 @@ alias kv='kubectl get events --sort-by=".metadata.creationTimestamp"'
 alias kva='kubectl get events --sort-by=".metadata.creationTimestamp" -A'
 
 alias ksecret='sc_helper_kube_secret'
+alias kcontainers='sc_helper_kube_containers'
 
 
 

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -40,16 +40,7 @@ alias kva='kubectl get events --sort-by=".metadata.creationTimestamp" -A'
 
 alias ksecret='sc_helper_kube_secret'
 
-# Kubernetes Watches
-alias kget-nodes='kubectl get nodes -o wide'
-alias kwatch-nodes='watch -n 1 kubectl get nodes -o wide'
-alias kget-pods='kubectl get pods -o wide'
-alias kwatch-pods='watch -n 1 kubectl get pods -o wide'
-alias ktop-pods='watch -n 1 kubectl top pods'
-alias kget-svc='kubectl get svc -o wide'
-alias kwatch-svc='watch -n 1 kubectl get svc -o wide'
-alias kget-pvc='kubectl get pvc -o wide'
-alias kwatch-pvc='watch -n 1 kubectl get pvc -o wide'
+
 
 
 


### PR DESCRIPTION
Remove specific Kubernetes `kget-*`, `kwatch-*`, and `ktop-pods` aliases from `.bash_aliases` as requested by the user.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-25eae891-1324-4af3-8197-eb48402c16f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25eae891-1324-4af3-8197-eb48402c16f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

